### PR TITLE
Serve client via Express and enable WS; health endpoint

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,16 @@
   "name": "starcheckers-server",
   "version": "1.0.0",
   "main": "index.js",
+  "type": "module",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "dev": "node --watch index.js",
+    "test": "node tests/run.js"
+  },
+  "dependencies": {
+    "cookie-parser": "^1.4.6",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "ws": "^8.18.0"
   }
 }


### PR DESCRIPTION
## Summary
- configure server package for ESM with start/dev/test scripts and dependencies
- rewrite server to serve static client, expose health endpoint, and handle WebSocket connections with heartbeat

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b6670922083318801fbb641b71e46