### PR TITLE
ESM named exports: matchmaker, game, telegram

### DIFF
--- a/server/game.js
+++ b/server/game.js
@@ -1,1 +1,51 @@
-// Game logic placeholder
+export const SIZE = 8;
+
+export function initialBoard() {
+  const board = Array.from({ length: SIZE }, () =>
+    Array(SIZE).fill(null)
+  );
+  for (let r = 0; r < 3; r++) {
+    for (let c = 0; c < SIZE; c++) {
+      if ((r + c) % 2 === 1) board[r][c] = 'b';
+    }
+  }
+  for (let r = SIZE - 3; r < SIZE; r++) {
+    for (let c = 0; c < SIZE; c++) {
+      if ((r + c) % 2 === 1) board[r][c] = 'w';
+    }
+  }
+  return board;
+}
+
+export function validateMove(board, mv, side) {
+  const { from, to } = mv;
+  const piece = board[from.r][from.c];
+  if (!piece || piece !== side) return false;
+  if (board[to.r][to.c]) return false;
+  const dr = to.r - from.r;
+  const dc = Math.abs(to.c - from.c);
+  if (side === 'w' && dr !== -1) return false;
+  if (side === 'b' && dr !== 1) return false;
+  return dc === 1;
+}
+
+export function applyMove(board, mv) {
+  const { from, to } = mv;
+  board[to.r][to.c] = board[from.r][from.c];
+  board[from.r][from.c] = null;
+  return board;
+}
+
+export function whoHasMoves(board) {
+  let white = false;
+  let black = false;
+  for (let r = 0; r < SIZE; r++) {
+    for (let c = 0; c < SIZE; c++) {
+      const p = board[r][c];
+      if (p === 'w') white = true;
+      if (p === 'b') black = true;
+    }
+  }
+  return { white, black };
+}
+

--- a/server/matchmaker.js
+++ b/server/matchmaker.js
@@ -1,1 +1,42 @@
-// Matchmaking logic placeholder
+export function createMatchmaker({ verifyInitData }) {
+  const rooms = new Map();
+  const queue = [];
+
+  function onMessage(ws, msg) {
+    if (msg.type === 'join') {
+      if (!queue.includes(ws)) queue.push(ws);
+      if (queue.length >= 2) {
+        const [a, b] = queue.splice(0, 2);
+        const roomId = `room_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+        rooms.set(roomId, [a, b]);
+        a.send(
+          JSON.stringify({ type: 'start', roomId, opponent: b.user })
+        );
+        b.send(
+          JSON.stringify({ type: 'start', roomId, opponent: a.user })
+        );
+      }
+    }
+  }
+
+  function onDisconnect(ws) {
+    const idx = queue.indexOf(ws);
+    if (idx >= 0) queue.splice(idx, 1);
+
+    for (const [id, players] of rooms) {
+      if (players.includes(ws)) {
+        rooms.delete(id);
+        players.forEach((p) => {
+          if (p !== ws) {
+            p.send(JSON.stringify({ type: 'opponent_disconnect' }));
+          }
+        });
+        break;
+      }
+    }
+  }
+
+  return { onMessage, onDisconnect };
+}
+
+export default undefined;

--- a/server/telegram.js
+++ b/server/telegram.js
@@ -1,1 +1,33 @@
-// Telegram API integration placeholder
+import crypto from 'crypto';
+
+export async function verifyInitData(initData) {
+  if (!initData) return false;
+  const params = new URLSearchParams(initData);
+  const hash = params.get('hash');
+  params.delete('hash');
+
+  const dataCheckString = [...params.entries()]
+    .sort()
+    .map(([k, v]) => `${k}=${v}`)
+    .join('\n');
+
+  const secret = crypto
+    .createHash('sha256')
+    .update(process.env.BOT_TOKEN ?? '')
+    .digest();
+
+  const hmac = crypto
+    .createHmac('sha256', secret)
+    .update(dataCheckString)
+    .digest('hex');
+
+  if (hmac !== hash) return false;
+
+  const user = params.get('user');
+  return { user: user ? JSON.parse(user) : null };
+}
+
+export async function createStarsInvoice({ amount, description }) {
+  return { ok: true, amount, description };
+}
+


### PR DESCRIPTION
## Summary
- convert server modules to ESM using named exports
- add placeholder matchmaker, game logic, and telegram helpers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b69062e548331bb16d89e16cf9a46