### PR TITLE
feat: improve checkers rules and audio

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,556 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no"/>
+<title>Русские шашки</title>
+<style>
+  :root{
+    --bg1:#1b1f29; --bg2:#2a2f3a; --panel:#2e323d; --accent:#c6934b;
+    --light:#e8d2ad; --dark:#7b5a2f; --red:#8b2d2d; --white:#f5f2ea;
+  }
+  *{box-sizing:border-box}
+  html,body{height:100%;margin:0;background:linear-gradient(180deg,#151923,#1a2030 40%,#0f1320);}
+  body{font:16px/1.4 -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Inter,Arial,sans-serif;color:#eef2ff;display:flex;justify-content:center;align-items:center}
+  .wrap{width:min(100vw,900px);padding:16px}
+  .card{
+    background: radial-gradient(1200px 600px at 50% -200px, rgba(255,255,255,.04), transparent 60%) , linear-gradient(180deg,#2c303b,#242833);
+    border-radius:18px; box-shadow:0 20px 50px rgba(0,0,0,.45), inset 0 1px 0 rgba(255,255,255,.04);
+    border:1px solid rgba(255,255,255,.06);
+  }
+  .header{display:flex;gap:12px;align-items:center;padding:14px 16px;border-bottom:1px solid rgba(255,255,255,.06)}
+  .brand{font-weight:700;letter-spacing:.4px}
+  .screens{padding:16px}
+  .row{display:flex;gap:16px;flex-wrap:wrap}
+  .col{flex:1 1 280px}
+  .btn{
+    background:linear-gradient(180deg,#f7d7a2,#d9a257);
+    color:#2b2114;border:none;border-radius:12px;padding:12px 16px;font-weight:700;cursor:pointer;
+    box-shadow:0 6px 24px rgba(0,0,0,.25); transition:transform .1s ease;
+  }
+  .btn:active{transform:translateY(1px)}
+  .btn.secondary{background:#3a3f4a;color:#e9edf6}
+  label.switch{display:flex;align-items:center;gap:10px;margin:8px 0}
+  label.switch input{accent-color:var(--accent);width:20px;height:20px}
+  .select, .input{
+    width:100%; padding:10px 12px; border-radius:10px; border:1px solid rgba(255,255,255,.08); background:#333846; color:#e9edf6;
+  }
+  .boardContainer{aspect-ratio:1/1; width:100%; max-width:680px; margin:0 auto; user-select:none; -webkit-user-select:none; touch-action:none}
+  canvas{width:100%;height:100%;display:block;border-radius:16px;box-shadow:inset 0 0 0 1px rgba(255,255,255,.08)}
+  .toolbar{display:flex;gap:8px;flex-wrap:wrap;align-items:center;margin-top:12px}
+  .meta{margin-top:10px;font-size:14px;opacity:.9;display:grid;grid-template-columns:1fr 1fr;gap:6px}
+  .hidden{display:none}
+  details.tests{margin-top:14px;background:#222735;border-radius:12px;padding:10px;border:1px solid rgba(255,255,255,.06)}
+  .badge{font-size:12px;padding:2px 8px;background:#394053;border-radius:999px;margin-left:8px;color:#cde}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="card">
+    <div class="header">
+      <div class="brand">Русские шашки</div>
+      <div style="flex:1"></div>
+      <button id="toMenu" class="btn secondary hidden">Настройки</button>
+    </div>
+
+    <div id="screenMenu" class="screens">
+      <div class="row">
+        <div class="col">
+          <h3>Игра</h3>
+          <label class="switch">Режим
+            <select id="mode" class="select">
+              <option value="ai">1 игрок (с ИИ)</option>
+              <option value="pvp">2 игрока</option>
+            </select>
+          </label>
+          <label class="switch">Уровень ИИ
+            <select id="level" class="select">
+              <option value="0">0 (быстрый)</option>
+              <option value="1" selected>1 (средний)</option>
+              <option value="2">2 (сложный)</option>
+            </select>
+          </label>
+          <label class="switch"><input id="mustCapture" type="checkbox" checked/> Бить обязательно</label>
+          <label class="switch">Цвет игрока
+            <select id="yourColor" class="select">
+              <option value="white" selected>Белые (начинают)</option>
+              <option value="black">Чёрные</option>
+            </select>
+          </label>
+          <label class="switch">Таймер (сек/ход)
+            <input id="turnSeconds" type="number" class="input" min="0" step="5" value="0" />
+          </label>
+        </div>
+        <div class="col">
+          <h3>Звук</h3>
+          <label class="switch"><input id="musicOn" type="checkbox" checked/> Музыка</label>
+          <label class="switch"><input id="sfxOn" type="checkbox" checked/> Звуки ходов</label>
+          <p style="opacity:.8">Музыка включится после первого нажатия.</p>
+          <div style="height:16px"></div>
+          <button id="startGame" class="btn">Новая игра</button>
+        </div>
+      </div>
+      <details class="tests">
+        <summary>Тесты<span id="testsBadge" class="badge">не запущены</span></summary>
+        <pre id="testsLog" style="white-space:pre-wrap"></pre>
+      </details>
+    </div>
+
+    <div id="screenGame" class="screens hidden">
+      <div class="boardContainer"><canvas id="board" width="1024" height="1024"></canvas></div>
+      <div class="toolbar">
+        <button id="btnUndo" class="btn secondary">Отменить</button>
+        <button id="btnHint" class="btn secondary">Подсказка</button>
+        <button id="btnRestart" class="btn">Сдаться / Новая</button>
+        <div style="flex:1"></div>
+        <label class="switch"><input id="toggleMusic" type="checkbox" checked/> Музыка</label>
+        <label class="switch"><input id="toggleSfx" type="checkbox" checked/> Звуки</label>
+      </div>
+      <div class="meta">
+        <div>Ход: <b id="turnLabel">—</b></div>
+        <div>Статус: <b id="statusLabel">—</b></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+/* ====================== Аудио ====================== */
+const AudioBus = (() => {
+  const ctx = {ac:null, music:null, gain:{music:null,sfx:null}, unlocked:false};
+  function ensure(){ if(ctx.ac) return;
+    ctx.ac = new (window.AudioContext||window.webkitAudioContext)();
+    ctx.gain.music = ctx.ac.createGain(); ctx.gain.music.gain.value=.25;
+    ctx.gain.sfx   = ctx.ac.createGain(); ctx.gain.sfx.gain.value=.6;
+    ctx.gain.music.connect(ctx.ac.destination);
+    ctx.gain.sfx.connect(ctx.ac.destination);
+  }
+  function unlock(){ ensure(); if(ctx.unlocked) return;
+    const b = ctx.ac.createBuffer(1, 1, 22050); const src = ctx.ac.createBufferSource(); src.buffer=b; src.connect(ctx.ac.destination); src.start(0);
+    ctx.unlocked = true;
+  }
+  function tone(freq,ms,which="sfx"){
+    ensure(); const o=ctx.ac.createOscillator(), g=ctx.ac.createGain();
+    o.frequency.value=freq; o.type="triangle"; g.gain.setValueAtTime(.0001,ctx.ac.currentTime);
+    g.gain.linearRampToValueAtTime(which==="sfx"? .6:.2, ctx.ac.currentTime+.01);
+    g.gain.exponentialRampToValueAtTime(.0001, ctx.ac.currentTime+ms/1000);
+    o.connect(g); g.connect(ctx.gain[which]); o.start(); o.stop(ctx.ac.currentTime+ms/1000+0.05);
+  }
+  function playMove(){ tone(520,120,"sfx"); }
+  function playCapture(){ tone(220,220,"sfx"); }
+  function playPromote(){ tone(880,260,"sfx"); }
+  function loopMusic(on){
+    ensure();
+    if(on){
+      if(ctx.music){ return; }
+      const o=ctx.ac.createOscillator(), l=ctx.ac.createOscillator();
+      o.type="sine"; l.type="triangle"; o.frequency.value=140; l.frequency.value=280;
+      o.connect(ctx.gain.music); l.connect(ctx.gain.music);
+      ctx.music={o,l}; o.start(); l.start();
+    }else{
+      if(ctx.music){ ctx.music.o.stop(); ctx.music.l.stop(); ctx.music=null; }
+    }
+  }
+  return {unlock, playMove, playCapture, playPromote, loopMusic,
+          setMusicGain:v=>{ensure(); ctx.gain.music.gain.value=v},
+          setSfxGain:v=>{ensure(); ctx.gain.sfx.gain.value=v}}
+})();
+
+/* =============== Вспомогательные структуры =============== */
+const SIZE=8, DARK=1, LIGHT=0;
+const Piece = (color,isKing=false)=>({c:color,k:isKing});
+function cloneBoard(b){ return b.map(row=>row.map(p=> p? {c:p.c,k:p.k}:null)); }
+function inside(x,y){ return x>=0 && x<SIZE && y>=0 && y<SIZE; }
+const DIRS = [[1,1],[1,-1],[-1,1],[-1,-1]];
+
+/* =============== Инициализация =============== */
+const UI = {
+  menu:document.getElementById('screenMenu'),
+  game:document.getElementById('screenGame'),
+  toMenu:document.getElementById('toMenu'),
+  board:document.getElementById('board'),
+  turn:document.getElementById('turnLabel'),
+  status:document.getElementById('statusLabel'),
+  start:document.getElementById('startGame'),
+  mustCap:document.getElementById('mustCapture'),
+  level:document.getElementById('level'),
+  mode:document.getElementById('mode'),
+  yourColor:document.getElementById('yourColor'),
+  turnSeconds:document.getElementById('turnSeconds'),
+  musicOn:document.getElementById('musicOn'), sfxOn:document.getElementById('sfxOn'),
+  tMusic:document.getElementById('toggleMusic'), tSfx:document.getElementById('toggleSfx'),
+  undo:document.getElementById('btnUndo'), hint:document.getElementById('btnHint'), restart:document.getElementById('btnRestart'),
+  testsLog:document.getElementById('testsLog'), testsBadge:document.getElementById('testsBadge')
+};
+
+const State = {
+  board:null, turn:LIGHT, history:[], mustCapture:true, mode:"ai", humanColor:LIGHT, aiDepth:1, timer:0,
+  lock:false, dragging:null, hover:null, selectable:[], movesCache:null, gameOver:false
+};
+
+/* =============== Стартовые позиции =============== */
+function startBoard(){
+  const b = Array.from({length:SIZE},()=>Array(SIZE).fill(null));
+  for(let y=0;y<3;y++){
+    for(let x=0;x<SIZE;x++) if((x+y)%2===1) b[y][x]=Piece(DARK,false);
+  }
+  for(let y=SIZE-3;y<SIZE;y++){
+    for(let x=0;x<SIZE;x++) if((x+y)%2===1) b[y][x]=Piece(LIGHT,false);
+  }
+  return b;
+}
+
+/* =============== Рендер =============== */
+const ctx = UI.board.getContext('2d');
+let cellPx = 1024/SIZE;
+function draw(){
+  const b=State.board || Array.from({length:SIZE},()=>Array(SIZE).fill(null));
+  ctx.clearRect(0,0,UI.board.width,UI.board.height);
+  for(let y=0;y<SIZE;y++){
+    for(let x=0;x<SIZE;x++){
+      const dark=((x+y)&1)===1;
+      ctx.fillStyle = dark? "#7a5a35" : "#d9b98a";
+      ctx.fillRect(x*cellPx,y*cellPx,cellPx,cellPx);
+    }
+  }
+  if(State.selectable.length){
+    ctx.fillStyle='rgba(80,180,255,.25)';
+    for(const [x,y] of State.selectable) ctx.fillRect(x*cellPx,y*cellPx,cellPx,cellPx);
+  }
+  if(State.hover){ ctx.fillStyle='rgba(255,255,100,.22)'; const [x,y]=State.hover; ctx.fillRect(x*cellPx,y*cellPx,cellPx,cellPx); }
+  if(State.dragging && State.dragging.targets){
+    ctx.fillStyle='rgba(50,230,120,.25)';
+    for(const t of State.dragging.targets){
+      ctx.beginPath(); ctx.arc((t.x+.5)*cellPx,(t.y+.5)*cellPx, cellPx*0.22, 0, Math.PI*2); ctx.fill();
+    }
+  }
+  for(let y=0;y<SIZE;y++){
+    for(let x=0;x<SIZE;x++){
+      const p=b[y][x]; if(!p) continue;
+      if(State.dragging && State.dragging.x===x && State.dragging.y===y) continue;
+      drawPiece(x,y,p);
+    }
+  }
+  if(State.dragging){
+    drawPiece(State.dragging.fx, State.dragging.fy, State.dragging.piece, true);
+  }
+}
+function drawPiece(x,y,p,free=false){
+  const cx=(x+.5)*cellPx, cy=(y+.5)*cellPx, r=cellPx*.36;
+  ctx.save();
+  if(free){ ctx.globalAlpha=.85; }
+  const grad=ctx.createRadialGradient(cx-r*.3,cy-r*.3,r*.2,cx,cy,r);
+  if(p.c===LIGHT){ grad.addColorStop(0,'#fff7e6'); grad.addColorStop(1,'#d9c39b'); }
+  else { grad.addColorStop(0,'#b04b4b'); grad.addColorStop(1,'#702020'); }
+  ctx.fillStyle=grad; ctx.beginPath(); ctx.arc(cx,cy,r,0,Math.PI*2); ctx.fill();
+  ctx.lineWidth=2; ctx.strokeStyle='rgba(0,0,0,.35)'; ctx.stroke();
+  if(p.k){
+    ctx.lineWidth=3; ctx.strokeStyle='rgba(255,215,120,.9)';
+    ctx.beginPath(); ctx.arc(cx,cy,r*.55,0,Math.PI*2); ctx.stroke();
+  }
+  ctx.restore();
+}
+
+/* =============== Генератор ходов (русские шашки) =============== */
+function movesFor(b, x,y, mustCap){
+  const p=b[y][x]; if(!p) return [];
+  const color=p.c, enemy=1-color;
+  const res=[];
+  function push(path,captures){
+    res.push({from:{x,y}, to:path[path.length-1], path, captures:[...captures], piece:p});
+  }
+  if(!mustCap){
+    if(!p.k){
+      const dir = (color===LIGHT? -1:1);
+      for(const dx of [-1,1]){
+        const nx=x+dx, ny=y+dir;
+        if(inside(nx,ny) && !b[ny][nx]) push([{x:nx,y:ny}],[]);
+      }
+    }else{
+      for(const [dx,dy] of DIRS){
+        let nx=x+dx, ny=y+dy;
+        while(inside(nx,ny) && !b[ny][nx]){ push([{x:nx,y:ny}],[]); nx+=dx; ny+=dy; }
+      }
+    }
+  }
+  function searchCap(cx,cy,board,caps,path,becameKing){
+    let found=false;
+    if(!p.k && !becameKing){
+      for(const [dx,dy] of DIRS){
+        const mx=cx+dx, my=cy+dy, lx=cx+2*dx, ly=cy+2*dy;
+        if(!inside(lx,ly)||!inside(mx,my)) continue;
+        if(board[my][mx] && board[my][mx].c===enemy && !board[ly][lx]){
+          const nb=cloneBoard(board);
+          nb[my][mx]=null; nb[cy][cx]=null; nb[ly][lx]=Piece(color,false);
+          let became = becameKing || (color===LIGHT? ly===0 : ly===SIZE-1);
+          if(became) nb[ly][lx].k=true;
+          searchCap(lx,ly,nb,[...caps,{x:mx,y:my}], [...path,{x:lx,y:ly}], became);
+          found=true;
+        }
+      }
+    }else{
+      for(const [dx,dy] of DIRS){
+        let nx=cx+dx, ny=cy+dy; let met=null;
+        while(inside(nx,ny)){
+          if(!met && board[ny][nx]==null){ nx+=dx; ny+=dy; continue; }
+          if(!met && board[ny][nx] && board[ny][nx].c===enemy){ met={x:nx,y:ny}; nx+=dx; ny+=dy; continue; }
+          if(met && board[ny] && board[ny][nx]==null){
+            const nb=cloneBoard(board);
+            nb[met.y][met.x]=null; nb[cy][cx]=null; nb[ny][nx]=Piece(color,true);
+            searchCap(nx,ny,nb,[...caps,{x:met.x,y:met.y}], [...path,{x:nx,y:ny}], true);
+            found=true; nx+=dx; ny+=dy; continue;
+          }
+          break;
+        }
+      }
+    }
+    if(!found && caps.length){ push(path,caps); }
+  }
+  searchCap(x,y,b,[],[],false);
+  if(res.some(m=>m.captures.length)) return res.filter(m=>m.captures.length>0);
+  return res;
+}
+
+function allMoves(b, turn, mustCap){
+  const ms=[];
+  for(let y=0;y<SIZE;y++) for(let x=0;x<SIZE;x++){
+    const p=b[y][x]; if(p && p.c===turn){ const list=movesFor(b,x,y,mustCap); for(const m of list) ms.push({...m, from:{x,y}}); }
+  }
+  if(mustCap){
+    const max = ms.reduce((a,m)=>Math.max(a,m.captures.length),0);
+    if(max>0) return ms.filter(m=>m.captures.length===max);
+    return allMoves(b, turn, false);
+  }
+  return ms;
+}
+
+/* =============== Применение хода (ЕДИНАЯ ТОЧКА) =============== */
+function playMove(state, move, {silent=false}={}){
+  if(!move) return state;
+  const b=cloneBoard(state.board);
+  const {from,to,captures}=move;
+  const src=b[from.y][from.x];
+  if(!src) return state;
+  b[from.y][from.x]=null;
+  const isPromotion = (!src.k && ((src.c===LIGHT && to.y===0) || (src.c===DARK && to.y===SIZE-1)));
+  b[to.y][to.x]=Piece(src.c, src.k || isPromotion);
+  for(const c of captures) b[c.y][c.x]=null;
+  const next = {
+    ...state,
+    board:b,
+    history:[...state.history, {move, board:state.board}],
+  };
+  if(!silent){
+    if(captures.length) AudioBus.playCapture(); else AudioBus.playMove();
+    if(isPromotion) AudioBus.playPromote();
+  }
+  const must = state.mustCapture && captures.length>0;
+  if(must){
+    const cont = movesFor(b, to.x,to.y, true).filter(m=>m.captures.length>0);
+    if(cont.length){
+      next.turn = state.turn;
+      State.selectable = [[to.x,to.y]];
+      State.dragging=null; State.movesCache=cont;
+      State.status = "Продолжайте серию";
+      return next;
+    }
+  }
+  next.turn = 1 - state.turn;
+  State.selectable=[]; State.movesCache=null;
+  const oppMoves = allMoves(b, next.turn, state.mustCapture);
+  if(oppMoves.length===0){
+    next.gameOver = true;
+    State.status = (next.turn===LIGHT? "Белые":"Чёрные")+" без ходов. Победа!";
+  }else{
+    State.status = "Идёт игра";
+  }
+  return next;
+}
+
+/* =============== ИИ (минимакс) =============== */
+function evaluate(b, me){
+  let score=0;
+  for(let y=0;y<SIZE;y++) for(let x=0;x<SIZE;x++){
+    const p=b[y][x]; if(!p) continue;
+    const w = (p.k? 3:1) + (p.c===LIGHT? (7-y)*.04 : y*.04);
+    score += p.c===me ? w : -w;
+  }
+  return score;
+}
+function minimax(b, turn, depth, mustCap, me, alpha=-1e9, beta=1e9){
+  if(depth===0){ return {score:evaluate(b, me)}; }
+  const moves = allMoves(b, turn, mustCap);
+  if(!moves.length) return {score: turn===me? -9999: 9999};
+  let best=null;
+  for(const m of moves){
+    const s={board:b,history:[],turn, mustCapture:mustCap};
+    const n = playMove(s, m, {silent:true});
+    const r = minimax(n.board, n.turn, depth-1, mustCap, me, alpha, beta);
+    const sc=r.score;
+    if(turn===me){
+      if(!best || sc>best.score){ best={score:sc, move:m}; alpha=Math.max(alpha,sc); }
+      if(beta<=alpha) break;
+    }else{
+      if(!best || sc<best.score){ best={score:sc, move:m}; beta=Math.min(beta,sc); }
+      if(beta<=alpha) break;
+    }
+  }
+  return best;
+}
+
+/* =============== Взаимодействие (тап/drag) =============== */
+function boardXY(evt){
+  const r=UI.board.getBoundingClientRect();
+  const x = Math.floor(( (evt.touches? evt.touches[0].clientX:evt.clientX) - r.left ) / r.width * SIZE);
+  const y = Math.floor(( (evt.touches? evt.touches[0].clientY:evt.clientY) - r.top ) / r.height * SIZE);
+  return [Math.max(0,Math.min(SIZE-1,x)), Math.max(0,Math.min(SIZE-1,y))];
+}
+UI.board.addEventListener('pointerdown', e=>{
+  if(State.lock||State.gameOver) return;
+  AudioBus.unlock();
+  const [x,y]=boardXY(e);
+  const p=State.board[y][x]; if(!p) return;
+  if(p.c!==State.turn) return;
+  let moves;
+  if(State.movesCache){
+    moves = State.movesCache.filter(m=>m.from.x===x && m.from.y===y);
+  }else{
+    moves=allMoves(State.board, State.turn, State.mustCapture).filter(m=>m.from.x===x&&m.from.y===y);
+    if(moves.some(m=>m.captures.length>0)){
+      const max = moves.reduce((a,m)=>Math.max(a,m.captures.length),0);
+      moves = moves.filter(m=>m.captures.length===max);
+    }
+  }
+  if(!moves.length) return;
+  if(State.movesCache && (x!==State.selectable[0][0] || y!==State.selectable[0][1])) return;
+  State.dragging={x,y, piece:p, fx:x, fy:y, targets:moves.map(m=>m.to), moves};
+  State.hover=[x,y];
+  State.selectable=[[x,y]];
+  draw();
+});
+UI.board.addEventListener('pointermove', e=>{
+  if(State.dragging){
+    const [x,y]=boardXY(e);
+    State.dragging.fx=x; State.dragging.fy=y;
+    draw();
+  }else{
+    const [x,y]=boardXY(e); State.hover=[x,y]; draw();
+  }
+});
+UI.board.addEventListener('pointerup', e=>{
+  if(!State.dragging) return;
+  const [x,y]=boardXY(e);
+  const cand = State.dragging.moves.find(m=>m.to.x===x && m.to.y===y);
+  if(cand){
+    Object.assign(State, playMove(State, cand));
+    syncUI();
+    if(State.mode==="ai" && State.turn!==State.humanColor && !State.gameOver){
+      thinkAI();
+    }
+  }
+  State.dragging=null; State.hover=null; draw();
+});
+
+/* =============== Игра/ИИ/Кнопки =============== */
+function syncUI(){
+  UI.turn.textContent = (State.turn===LIGHT? "Белые":"Чёрные");
+  UI.status.textContent = State.status || "Идёт игра";
+  draw();
+}
+async function thinkAI(){
+  State.lock=true; UI.status.textContent="ИИ думает…"; draw();
+  await new Promise(r=>setTimeout(r, 120));
+  const depth = State.aiDepth+1;
+  const best = minimax(State.board, State.turn, depth, State.mustCapture, State.turn);
+  Object.assign(State, playMove(State, best.move));
+  State.lock=false; syncUI();
+}
+function newGameFromMenu(){
+  AudioBus.unlock();
+  AudioBus.loopMusic(true);
+  AudioBus.setMusicGain(UI.musicOn.checked? .25:0);
+  AudioBus.setSfxGain(UI.sfxOn.checked? .6:0);
+  State.board=startBoard(); State.turn=LIGHT; State.history=[]; State.gameOver=false; State.status="Идёт игра";
+  State.mustCapture = UI.mustCap.checked;
+  State.mode = UI.mode.value;
+  State.humanColor = UI.yourColor.value==="white"? LIGHT: DARK;
+  State.aiDepth = parseInt(UI.level.value,10);
+  State.timer = Math.max(0, parseInt(UI.turnSeconds.value||"0",10));
+  State.selectable=[]; State.movesCache=null; State.dragging=null; State.hover=null;
+  UI.tMusic.checked = UI.musicOn.checked; UI.tSfx.checked = UI.sfxOn.checked;
+  if(State.mode==="ai" && State.humanColor!==State.turn){ setTimeout(thinkAI, 200); }
+  toScreen('game'); syncUI();
+}
+function toScreen(which){
+  const toGame = which==='game';
+  UI.menu.classList.toggle('hidden', toGame);
+  UI.game.classList.toggle('hidden', !toGame);
+  UI.toMenu.classList.toggle('hidden', !toGame);
+}
+UI.undo.addEventListener('click', ()=>{
+  if(!State.history.length) return;
+  const last=State.history.pop();
+  State.board=last.board; State.turn=1-State.turn; State.gameOver=false; State.status="Ход отменён";
+  State.selectable=[]; State.movesCache=null;
+  draw(); syncUI();
+});
+UI.hint.addEventListener('click', ()=>{
+  const moves=allMoves(State.board, State.turn, State.mustCapture);
+  if(!moves.length) return;
+  const best=minimax(State.board, State.turn, (State.aiDepth+1), State.mustCapture, State.turn);
+  State.selectable=[[best.move.from.x,best.move.from.y]];
+  State.dragging={x:best.move.from.x,y:best.move.from.y, fx:best.move.to.x, fy:best.move.to.y, piece:State.board[best.move.from.y][best.move.from.x], targets:[best.move.to], moves:[best.move]};
+  State.status="Подсказка: выделен лучший ход";
+  draw();
+});
+UI.restart.addEventListener('click', ()=>{ toScreen('menu'); });
+UI.tMusic.addEventListener('change', e=>AudioBus.setMusicGain(e.target.checked? .25:0));
+UI.tSfx.addEventListener('change', e=>AudioBus.setSfxGain(e.target.checked? .6:0));
+UI.start.addEventListener('click', newGameFromMenu);
+UI.toMenu.addEventListener('click', ()=>toScreen('menu'));
+(function boot(){ draw(); runTests(); })();
+
+/* ====================== ТЕСТЫ ====================== */
+function tAssert(cond,msg){ if(!cond) throw new Error(msg); }
+function runTests(){
+  const logs=[];
+  function log(s){ logs.push(s); }
+  try{
+    const b=startBoard();
+    let w=0,d=0; for(let y=0;y<SIZE;y++)for(let x=0;x<SIZE;x++){ const p=b[y][x]; if(p){ if(p.c===LIGHT) w++; else d++; }}
+    tAssert(w===12 && d===12, "Стартовые: 12/12"); log("OK: стартовые 12/12");
+    const m1=allMoves(b,LIGHT,true);
+    tAssert(m1.length>0,"Ходы у белых есть при старте"); log("OK: белые имеют стартовые ходы");
+    const any=m1.find(m=>m.captures.length===0) || m1[0];
+    const s={board:b,turn:LIGHT,history:[],mustCapture:true};
+    const n=playMove(s,any,{silent:true});
+    tAssert(n.board !== b && n.turn===DARK,"playMove меняет состояние и ход"); log("OK: playMove выполняет ход");
+    const bb=Array.from({length:SIZE},()=>Array(SIZE).fill(null));
+    bb[1][2]=Piece(LIGHT,false);
+    const mv={from:{x:2,y:1},to:{x:1,y:0},captures:[],piece:bb[1][2]};
+    const ns=playMove({board:bb,turn:LIGHT,history:[],mustCapture:false},mv,{silent:true});
+    tAssert(ns.board[0][1] && ns.board[0][1].k===true,"Промоция в дамку"); log("OK: промоция работает");
+    const cb=Array.from({length:SIZE},()=>Array(SIZE).fill(null));
+    cb[5][2]=Piece(LIGHT,true); cb[4][3]=Piece(DARK,false);
+    const ms = movesFor(cb,2,5,true);
+    const cap = ms.find(m=>m.captures.length===1);
+    tAssert(!!cap,"Дамка может бить через клетку"); log("OK: дамка бьёт на расстоянии");
+    // Дополнительные тесты
+    const tb=Array.from({length:SIZE},()=>Array(SIZE).fill(null));
+    tb[5][2]=Piece(LIGHT,false); tb[4][3]=Piece(DARK,false); tb[2][5]=Piece(DARK,false); tb[6][5]=Piece(LIGHT,false); tb[5][6]=Piece(DARK,false);
+    const am=allMoves(tb,LIGHT,true);
+    tAssert(am.length===1 && am[0].captures.length===2, "Выбран только маршрут с макс. взятиями"); log("OK: при обязательном бое выбирается макс маршрут");
+    const pb=Array.from({length:SIZE},()=>Array(SIZE).fill(null));
+    pb[2][1]=Piece(LIGHT,false); pb[1][2]=Piece(DARK,false); pb[1][4]=Piece(DARK,false);
+    const pm=movesFor(pb,1,2,true)[0];
+    tAssert(pm.captures.length===2, "Серия продолжается после промоции"); log("OK: серия продолжается после промоции");
+    document.getElementById('testsBadge').textContent="все пройдены";
+  }catch(e){
+    document.getElementById('testsBadge').textContent="ошибки";
+    logs.push("Ошибка теста: "+e.message);
+  }
+  document.getElementById('testsLog').textContent=logs.join("\n");
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- enforce Russian checkers capture rules with max captures and correct series continuation
- fix drag logic and audio unlocking; toggles now control gain
- add regression tests for promotion series and max capture

## Testing
- `node index.html tests via jsdom`

------
https://chatgpt.com/codex/tasks/task_e_689b8ced0b6c83319fa6ab6cf7a80879