### PR TITLE
Clarify optional authentication and simplify matchmaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,9 @@
 
 ## Деплой
 Статические файлы подключаются с параметром версии `?v=<timestamp>` для предотвращения кэширования. При деплое обновляйте параметр в ссылках и выполняйте принудительный "Deploy latest commit".
+
+## Authentication
+
+WebSocket clients may optionally send an `auth` message containing Telegram `initData`.
+Verified users receive their Telegram profile; otherwise the server assigns an
+anonymous identity. Matchmaking works for both verified and anonymous players.

--- a/server/index.js
+++ b/server/index.js
@@ -38,7 +38,8 @@ const server = createServer(app);
 
 // WebSocket
 const wss = new WebSocketServer({ server, path: '/ws' });
-const mm = createMatchmaker({ verifyInitData });
+// Matchmaking works for both authenticated and anonymous users.
+const mm = createMatchmaker();
 
 wss.on('connection', (ws) => {
   ws.isAlive = true;

--- a/server/matchmaker.js
+++ b/server/matchmaker.js
@@ -1,4 +1,7 @@
-export function createMatchmaker({ verifyInitData }) {
+export function createMatchmaker() {
+  // Authentication is handled at the WebSocket layer. The matchmaker accepts
+  // both authenticated and anonymous players, so no extra verification is
+  // performed here.
   const rooms = new Map();
   const queue = [];
 


### PR DESCRIPTION
## Summary
- Drop unused `verifyInitData` dependency from matchmaker and allow anonymous participants
- Document optional authentication behavior in README and add clarifying comments

## Testing
- `npm test`
- Verified two WebSocket clients can join and start a match without auth

------
https://chatgpt.com/codex/tasks/task_e_689bcff54ae48331838af78278e6d734