### PR TITLE
Add captures, king moves, and promotion logic to server

### DIFF
--- a/server/game.js
+++ b/server/game.js
@@ -19,20 +19,78 @@ export function initialBoard() {
 
 export function validateMove(board, mv, side) {
   const { from, to } = mv;
+  const captures = mv.captures || [];
   const piece = board[from.r][from.c];
-  if (!piece || piece !== side) return false;
+  if (!piece || piece.toLowerCase() !== side) return false;
   if (board[to.r][to.c]) return false;
-  const dr = to.r - from.r;
-  const dc = Math.abs(to.c - from.c);
-  if (side === 'w' && dr !== -1) return false;
-  if (side === 'b' && dr !== 1) return false;
-  return dc === 1;
+
+  const isKing = piece === 'W' || piece === 'B';
+  const temp = board.map(row => row.slice());
+  const opponent = side === 'w' ? ['b', 'B'] : ['w', 'W'];
+  let cur = { ...from };
+
+  // remove piece from starting square for simulation
+  temp[from.r][from.c] = null;
+
+  if (captures.length) {
+    for (const cap of captures) {
+      const dr = cap.r - cur.r;
+      const dc = cap.c - cur.c;
+      if (Math.abs(dr) !== 1 || Math.abs(dc) !== 1) return false;
+      if (!isKing) {
+        const dir = side === 'w' ? -1 : 1;
+        if (dr !== dir) return false;
+      }
+      const landing = { r: cap.r + dr, c: cap.c + dc };
+      if (
+        landing.r < 0 ||
+        landing.r >= SIZE ||
+        landing.c < 0 ||
+        landing.c >= SIZE
+      )
+        return false;
+      const captured = temp[cap.r][cap.c];
+      if (!captured || !opponent.includes(captured)) return false;
+      if (temp[landing.r][landing.c] !== null) return false;
+      // remove captured piece and move current position
+      temp[cap.r][cap.c] = null;
+      cur = landing;
+    }
+    // final landing square must match 'to'
+    if (cur.r !== to.r || cur.c !== to.c) return false;
+  } else {
+    const dr = to.r - from.r;
+    const dc = to.c - from.c;
+    if (Math.abs(dc) !== 1) return false;
+    if (!isKing) {
+      const dir = side === 'w' ? -1 : 1;
+      if (dr !== dir) return false;
+    } else {
+      if (Math.abs(dr) !== 1) return false;
+    }
+  }
+
+  // promotion check
+  mv.promote = false;
+  if (!isKing) {
+    if ((side === 'w' && to.r === 0) || (side === 'b' && to.r === SIZE - 1)) {
+      mv.promote = true;
+    }
+  }
+
+  return true;
 }
 
 export function applyMove(board, mv) {
   const { from, to } = mv;
-  board[to.r][to.c] = board[from.r][from.c];
+  const captures = mv.captures || [];
+  let piece = board[from.r][from.c];
   board[from.r][from.c] = null;
+  for (const cap of captures) {
+    board[cap.r][cap.c] = null;
+  }
+  if (mv.promote) piece = piece.toUpperCase();
+  board[to.r][to.c] = piece;
   return board;
 }
 
@@ -42,8 +100,8 @@ export function whoHasMoves(board) {
   for (let r = 0; r < SIZE; r++) {
     for (let c = 0; c < SIZE; c++) {
       const p = board[r][c];
-      if (p === 'w') white = true;
-      if (p === 'b') black = true;
+      if (p && p.toLowerCase() === 'w') white = true;
+      if (p && p.toLowerCase() === 'b') black = true;
     }
   }
   return { white, black };

--- a/server/tests/run.js
+++ b/server/tests/run.js
@@ -1,1 +1,97 @@
+import assert from 'assert';
+import { initialBoard, validateMove, applyMove } from '../game.js';
+
 console.log('Running tests');
+
+function testSimpleMove() {
+  const board = initialBoard();
+  const mv = { from: { r: 5, c: 0 }, to: { r: 4, c: 1 } };
+  assert.strictEqual(validateMove(board, mv, 'w'), true, 'simple move should be valid');
+  applyMove(board, mv);
+  assert.strictEqual(board[4][1], 'w');
+  assert.strictEqual(board[5][0], null);
+}
+
+function testInvalidSimpleMove() {
+  const board = initialBoard();
+  const mv = { from: { r: 5, c: 0 }, to: { r: 6, c: 1 } }; // backward move
+  assert.strictEqual(validateMove(board, mv, 'w'), false, 'backward move should be invalid');
+}
+
+function testCapture() {
+  const board = initialBoard();
+  board[4][3] = 'b';
+  const mv = { from: { r: 5, c: 2 }, to: { r: 3, c: 4 }, captures: [{ r: 4, c: 3 }] };
+  assert.strictEqual(validateMove(board, mv, 'w'), true, 'capture should be valid');
+  applyMove(board, mv);
+  assert.strictEqual(board[3][4], 'w');
+  assert.strictEqual(board[4][3], null);
+}
+
+function testInvalidCapture() {
+  const board = initialBoard();
+  board[4][3] = 'b';
+  board[3][4] = 'b'; // landing square occupied
+  const mv = { from: { r: 5, c: 2 }, to: { r: 3, c: 4 }, captures: [{ r: 4, c: 3 }] };
+  assert.strictEqual(validateMove(board, mv, 'w'), false, 'capture with occupied landing should be invalid');
+}
+
+function testKingMove() {
+  const board = initialBoard();
+  board[4][3] = 'W';
+  board[5][2] = null;
+  const mv = { from: { r: 4, c: 3 }, to: { r: 5, c: 2 } };
+  assert.strictEqual(validateMove(board, mv, 'w'), true, 'king should move backwards');
+  applyMove(board, mv);
+  assert.strictEqual(board[5][2], 'W');
+}
+
+function testInvalidKingMove() {
+  const board = initialBoard();
+  board[4][3] = 'W';
+  board[5][2] = null;
+  const mv = { from: { r: 4, c: 3 }, to: { r: 6, c: 5 } }; // too far
+  assert.strictEqual(validateMove(board, mv, 'w'), false, 'king moving too far should be invalid');
+}
+
+function testPromotion() {
+  const board = initialBoard();
+  board[1][2] = 'w';
+  board[0][3] = null;
+  const mv = { from: { r: 1, c: 2 }, to: { r: 0, c: 3 } };
+  assert.strictEqual(validateMove(board, mv, 'w'), true, 'promotion move should be valid');
+  assert.strictEqual(mv.promote, true, 'promotion flag should be set');
+  applyMove(board, mv);
+  assert.strictEqual(board[0][3], 'W');
+}
+
+function testMultiCapture() {
+  const board = Array.from({ length: 8 }, () => Array(8).fill(null));
+  board[5][0] = 'w';
+  board[4][1] = 'b';
+  board[2][3] = 'b';
+  const mv = {
+    from: { r: 5, c: 0 },
+    to: { r: 1, c: 4 },
+    captures: [
+      { r: 4, c: 1 },
+      { r: 2, c: 3 }
+    ]
+  };
+  assert.strictEqual(validateMove(board, mv, 'w'), true, 'multi-capture should be valid');
+  applyMove(board, mv);
+  assert.strictEqual(board[1][4], 'w');
+  assert.strictEqual(board[4][1], null);
+  assert.strictEqual(board[2][3], null);
+}
+
+testSimpleMove();
+testInvalidSimpleMove();
+testCapture();
+testInvalidCapture();
+testKingMove();
+testInvalidKingMove();
+testPromotion();
+testMultiCapture();
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- Support captures (including multi-jumps), king movement in both directions, and promotion to king in `validateMove`
- Apply capture sequences and promotion updates in `applyMove`; track kings in `whoHasMoves`
- Add comprehensive tests for simple moves, captures, king moves, multi-capture and promotion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bcff67f68833192f9e3c75e3323d2