### PR TITLE
Improve theme switching and music loop

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
 </div>
 
 <script type="module">
-  import { initAudio, toggleMusic, playMove as playMoveSfx } from './src/audio.js?v=1';
+  import { initAudio, toggleMusic, playMove as playMoveSfx } from './src/audio.js?v=2';
   import { showEndModal } from './src/modal.js?v=1';
   import { getLegalMoves } from './src/moves.js?v=1';
   window.AudioAPI = { initAudio, toggleMusic, playMove: playMoveSfx, showEndModal, getLegalMoves };
@@ -176,12 +176,24 @@ function startBoard(){
 /* =============== Рендер =============== */
 const ctx = UI.board.getContext('2d');
 let cellPx = 1024/SIZE;
+let themeColors = {};
+
+function updateThemeColors(){
+  const st = getComputedStyle(document.body);
+  themeColors = {
+    boardLight: st.getPropertyValue('--board-light').trim(),
+    boardDark: st.getPropertyValue('--board-dark').trim(),
+    pieceLight: st.getPropertyValue('--piece-light').trim(),
+    pieceDark: st.getPropertyValue('--piece-dark').trim(),
+  };
+}
 
 const savedSettings = JSON.parse(localStorage.getItem('settings')||'{}');
 UI.musicOn.checked = savedSettings.music ?? true;
 UI.sfxOn.checked = savedSettings.sfx ?? true;
 UI.theme.value = savedSettings.theme || 'classic';
 document.body.classList.add('theme-'+UI.theme.value);
+updateThemeColors();
 UI.tMusic.checked = UI.musicOn.checked;
 UI.tSfx.checked = UI.sfxOn.checked;
 
@@ -198,6 +210,8 @@ UI.sfxOn.addEventListener('change', ()=>{ UI.tSfx.checked = UI.sfxOn.checked; sa
 UI.theme.addEventListener('change', ()=>{
   document.body.classList.remove('theme-classic','theme-walnut','theme-graphite');
   document.body.classList.add('theme-'+UI.theme.value);
+  updateThemeColors();
+  draw();
   saveSettings();
 });
 function draw(){
@@ -206,7 +220,7 @@ function draw(){
   for(let y=0;y<SIZE;y++){
     for(let x=0;x<SIZE;x++){
       const dark=((x+y)&1)===1;
-      ctx.fillStyle = dark? "#7a5a35" : "#d9b98a";
+      ctx.fillStyle = dark? themeColors.boardDark : themeColors.boardLight;
       ctx.fillRect(x*cellPx,y*cellPx,cellPx,cellPx);
     }
   }
@@ -237,8 +251,8 @@ function drawPiece(x,y,p,free=false){
   ctx.save();
   if(free){ ctx.globalAlpha=.85; }
   const grad=ctx.createRadialGradient(cx-r*.3,cy-r*.3,r*.2,cx,cy,r);
-  if(p.c===LIGHT){ grad.addColorStop(0,'#fff7e6'); grad.addColorStop(1,'#d9c39b'); }
-  else { grad.addColorStop(0,'#b04b4b'); grad.addColorStop(1,'#702020'); }
+  if(p.c===LIGHT){ grad.addColorStop(0,'#fff'); grad.addColorStop(1,themeColors.pieceLight); }
+  else { grad.addColorStop(0,'#7a0000'); grad.addColorStop(1,themeColors.pieceDark); }
   ctx.fillStyle=grad; ctx.beginPath(); ctx.arc(cx,cy,r,0,Math.PI*2); ctx.fill();
   ctx.lineWidth=2; ctx.strokeStyle='rgba(0,0,0,.35)'; ctx.stroke();
   if(p.k){

--- a/src/audio.js
+++ b/src/audio.js
@@ -10,6 +10,18 @@ function createContext() {
   masterGain.connect(ctx.destination);
 }
 
+function playNote(time, freq, dur = 0.3) {
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.type = "square";
+  osc.frequency.value = freq;
+  gain.gain.setValueAtTime(0, time);
+  gain.gain.linearRampToValueAtTime(0.4, time + 0.01);
+  gain.gain.exponentialRampToValueAtTime(0.001, time + dur);
+  osc.connect(gain); gain.connect(compressor);
+  osc.start(time); osc.stop(time + dur + 0.05);
+}
+
 function playChord(time, notes, dur = 0.6) {
   notes.forEach(freq => {
     const osc = ctx.createOscillator();
@@ -44,24 +56,21 @@ function playChord(time, notes, dur = 0.6) {
 }
 
 function scheduleLoop() {
-  const bar = 2.4; // размер такта
+  const beat = 0.35; // ~170 BPM
   const start = ctx.currentTime + 0.05;
-  for (let i=0;i<8;i++) {
-    const t = start + i*bar;
-    // Спокойная последовательность: Cmaj7, Am7, Dm7, G7
-    const seq = [
-      [261.63, 329.63, 392.00], // C E G
-      [220.00, 293.66, 349.23], // A C D#
-      [293.66, 349.23, 440.00], // D F A
-      [196.00, 246.94, 392.00], // G B G
-    ];
-    const chord = seq[i%4];
-    playChord(t, chord, 1.8);
-    // лёгкий колокольчик на каждую долю
-    for (let k=0;k<4;k++) playChord(t + k*0.6, [880], 0.25);
-  }
-  // перезапуск
-  setTimeout(scheduleLoop, 800); 
+  const melody = [
+    329.63,392.00,440.00,392.00,329.63,329.63,392.00,329.63,
+    261.63,293.66,246.94,261.63,220.00,246.94,261.63,329.63
+  ];
+  melody.forEach((f,i)=> playNote(start + i*beat, f, beat*0.9));
+  const chords = [
+    [261.63,329.63,392.00],
+    [293.66,349.23,440.00],
+    [261.63,329.63,392.00],
+    [220.00,277.18,329.63]
+  ];
+  chords.forEach((ch,i)=> playChord(start + i*beat*4, ch, beat*4));
+  setTimeout(scheduleLoop, melody.length * beat * 1000 - 100);
 }
 
 export function initAudio() { createContext(); }


### PR DESCRIPTION
## Summary
- use CSS variables to recolor the board and pieces when themes change
- replace ambient loop with a catchy square-wave melody

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bd3115314833181db5ab0f2897ab2