### PR TITLE
Prevent mini app from closing on swipe

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -1,5 +1,7 @@
 // Telegram
 const tg = window.Telegram?.WebApp; tg?.expand(); tg?.ready();
+// Prevent closing the mini app when swiping vertically
+tg?.disableVerticalSwipe?.();
 
 // WS URL
 const WS_URL = (location.origin.replace('http','ws')) + '/ws';

--- a/public/app.js
+++ b/public/app.js
@@ -1,5 +1,7 @@
 // Telegram
 const tg = window.Telegram?.WebApp; tg?.expand(); tg?.ready();
+// Prevent the mini app from closing on vertical swipes
+tg?.disableVerticalSwipe?.();
 
 // WS URL: рендер
 const WS_URL = (location.origin.replace('http','ws')) + '/ws';


### PR DESCRIPTION
## Summary
- disable Telegram vertical swipe to avoid mini app collapsing during game input

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c5d77e4948331925575510029cf60