### PR TITLE
Intercept iOS WebView gestures for StarCheckers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@
 WebSocket clients may optionally send an `auth` message containing Telegram `initData`.
 Verified users receive their Telegram profile; otherwise the server assigns an
 anonymous identity. Matchmaking works for both verified and anonymous players.
+
+## Telegram Mini App — жесты
+- В `styles.css` глобально отключаются прокрутка и pull-to-refresh: `overflow: hidden`, `overscroll-behavior: none`, фиксированный контейнер `#app`.
+- Игровая область помечена как `touch-action: none`, чтобы браузер не перехватывал pan/zoom.
+- Обработчики `pointer`/`touch` событий добавлены с опцией `{ passive:false }` и вызывают `preventDefault()` в `gestures-guard.js`.
+- При старте мини-апа выполняется `Telegram.WebApp.expand()` и задаётся фон через `setBackgroundColor`.

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ru">
 <head>
 <meta charset="utf-8" />
-<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
 <meta http-equiv="Cache-Control" content="no-store"/>
 <title>Русские шашки</title>
 <link rel="stylesheet" href="./styles.css?v=1">
@@ -12,7 +12,7 @@
     --light:#e8d2ad; --dark:#7b5a2f; --red:#8b2d2d; --white:#f5f2ea;
   }
   *{box-sizing:border-box}
-  html,body{height:100%;margin:0;background:linear-gradient(180deg,#151923,#1a2030 40%,#0f1320);touch-action:none;overscroll-behavior:none;}
+  html,body{height:100%;margin:0;background:linear-gradient(180deg,#151923,#1a2030 40%,#0f1320);}
   body{font:16px/1.4 -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Inter,Arial,sans-serif;color:#eef2ff;display:flex;justify-content:center;align-items:center;overflow:hidden}
   .wrap{width:min(100vw,900px);padding:16px}
   .card{
@@ -45,7 +45,7 @@
 </style>
 </head>
 <body>
-<div class="wrap">
+<div id="app" class="wrap">
   <div class="card">
     <div class="header">
       <div class="brand">Русские шашки</div>
@@ -95,7 +95,7 @@
     </div>
 
     <div id="screenGame" class="screens hidden">
-      <div class="boardContainer"><canvas id="board" width="1024" height="1024"></canvas></div>
+      <div class="boardContainer"><canvas id="board" class="board" width="1024" height="1024"></canvas></div>
       <div class="toolbar">
         <button id="btnUndo" class="btn secondary">Отменить</button>
         <button id="btnHint" class="btn secondary">Подсказка</button>
@@ -111,6 +111,7 @@
 </div>
 </div>
 
+<script src="./src/gestures-guard.js"></script>
 <script type="module">
   import { initAudio, playMove as playMoveSfx } from './src/audio.js?v=2';
   import { showEndModal } from './src/modal.js?v=1';
@@ -125,6 +126,10 @@
 </script>
 
 <script>
+if (window.Telegram && Telegram.WebApp) {
+  try { Telegram.WebApp.expand(); } catch(e){}
+  try { Telegram.WebApp.setBackgroundColor('#0f172a'); } catch(e){}
+}
 
 /* =============== Вспомогательные структуры =============== */
 const SIZE=8, DARK=1, LIGHT=0;
@@ -406,13 +411,16 @@ function minimax(b, turn, depth, mustCap, me, alpha=-1e9, beta=1e9){
 }
 
 /* =============== Взаимодействие (тап/drag) =============== */
+const boardEl = UI.board;
 function boardXY(evt){
-  const r=UI.board.getBoundingClientRect();
-  const x = Math.floor(( (evt.touches? evt.touches[0].clientX:evt.clientX) - r.left ) / r.width * SIZE);
-  const y = Math.floor(( (evt.touches? evt.touches[0].clientY:evt.clientY) - r.top ) / r.height * SIZE);
+  const r=boardEl.getBoundingClientRect();
+  const clientX = evt.touches ? evt.touches[0].clientX : evt.clientX;
+  const clientY = evt.touches ? evt.touches[0].clientY : evt.clientY;
+  const x = Math.floor((clientX - r.left) / r.width * SIZE);
+  const y = Math.floor((clientY - r.top) / r.height * SIZE);
   return [Math.max(0,Math.min(SIZE-1,x)), Math.max(0,Math.min(SIZE-1,y))];
 }
-UI.board.addEventListener('pointerdown', e=>{
+function onPointerDown(e){
   if(State.lock||State.gameOver) return;
   const [x,y]=boardXY(e);
   const p=State.board[y][x]; if(!p) return;
@@ -433,8 +441,8 @@ UI.board.addEventListener('pointerdown', e=>{
   State.hover=[x,y];
   State.selectable=[[x,y]];
   draw();
-});
-UI.board.addEventListener('pointermove', e=>{
+}
+function onPointerMove(e){
   if(State.dragging){
     const [x,y]=boardXY(e);
     State.dragging.fx=x; State.dragging.fy=y;
@@ -442,8 +450,8 @@ UI.board.addEventListener('pointermove', e=>{
   }else{
     const [x,y]=boardXY(e); State.hover=[x,y]; draw();
   }
-});
-UI.board.addEventListener('pointerup', e=>{
+}
+function onPointerUp(e){
   if(!State.dragging) return;
   const [x,y]=boardXY(e);
   const cand = State.dragging.moves.find(m=>m.to.x===x && m.to.y===y);
@@ -455,7 +463,10 @@ UI.board.addEventListener('pointerup', e=>{
     }
   }
   State.dragging=null; State.hover=null; draw();
-});
+}
+['pointerdown','mousedown','touchstart'].forEach(t=>boardEl.addEventListener(t,onPointerDown,{passive:false}));
+['pointermove','mousemove','touchmove'].forEach(t=>boardEl.addEventListener(t,onPointerMove,{passive:false}));
+['pointerup','mouseup','touchend','touchcancel'].forEach(t=>boardEl.addEventListener(t,onPointerUp,{passive:false}));
 
 /* =============== Игра/ИИ/Кнопки =============== */
 function syncUI(){

--- a/src/gestures-guard.js
+++ b/src/gestures-guard.js
@@ -1,0 +1,21 @@
+(function () {
+  const isTG = !!(window.Telegram && Telegram.WebApp);
+  if (isTG) {
+    try { Telegram.WebApp.expand(); } catch(e){}
+    try { Telegram.WebApp.enableClosingConfirmation(); } catch(e){}
+  }
+  function blockTouch(e){
+    const board = document.querySelector('.board');
+    if (!board) return;
+    if (e.target === board || board.contains(e.target)) {
+      e.preventDefault();
+    }
+  }
+  window.addEventListener('gesturestart', e => e.preventDefault(), { passive:false });
+  window.addEventListener('gesturechange', e => e.preventDefault(), { passive:false });
+  window.addEventListener('gestureend',   e => e.preventDefault(), { passive:false });
+  document.addEventListener('touchmove',  blockTouch, { passive:false });
+  document.addEventListener('touchstart', blockTouch, { passive:false });
+  document.addEventListener('pointermove', blockTouch, { passive:false });
+  document.addEventListener('pointerdown', blockTouch, { passive:false });
+})();

--- a/styles.css
+++ b/styles.css
@@ -14,6 +14,20 @@
   --board-light:#2b2f36; --board-dark:#1a1d23;
   --piece-light:#f2f2f2; --piece-dark:#b32d2d;
 }
+html, body {
+  height: 100%;
+  overflow: hidden;
+  overscroll-behavior: none;
+  -webkit-overflow-scrolling: auto;
+}
+#app, .app-root {
+  position: fixed;
+  inset: 0;
+}
+.board, .board * {
+  touch-action: none;
+  -ms-touch-action: none;
+}
 body{ background:var(--bg); color:var(--text); }
 .board .cell.light{ background:var(--board-light); }
 .board .cell.dark{  background:var(--board-dark); }


### PR DESCRIPTION
## Summary
- Disable native scrolling and gestures with new CSS rules and fixed app container
- Add gestures-guard.js to block browser gestures and expand Telegram WebApp
- Handle board moves via pointer events with preventDefault and Telegram init tweaks
- Document gesture handling for Telegram Mini App in README

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c637994dc833196c3731234103368