### PR TITLE
feat: improve telegram viewport handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,9 @@ anonymous identity. Matchmaking works for both verified and anonymous players.
 - Игровая область помечена как `touch-action: none`, чтобы браузер не перехватывал pan/zoom.
 - Обработчики `pointer`/`touch` событий добавлены с опцией `{ passive:false }` и вызывают `preventDefault()` в `gestures-guard.js`.
 - При старте мини-апа выполняется `Telegram.WebApp.expand()` и задаётся фон через `setBackgroundColor`.
+
+## Адаптация в Telegram WebApp
+- Используются метатег `viewport-fit=cover` и CSS-переменные `env(safe-area-inset-*)` для учёта вырезов экрана.
+- Переменная `--vh` рассчитывается на основе `Telegram.WebApp.viewportStableHeight` и обновляется при изменении размеров.
+- `ResizeObserver` обеспечивает точный квадрат доски без обрезаний и прокрутки.
+- Разметка построена сеткой `header / main / footer`, что упрощает адаптивное размещение элементов.

--- a/index.html
+++ b/index.html
@@ -3,23 +3,14 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
+<meta name="apple-mobile-web-app-capable" content="yes">
 <meta http-equiv="Cache-Control" content="no-store"/>
 <title>Русские шашки</title>
 <link rel="stylesheet" href="./styles.css?v=1">
+<script src="https://telegram.org/js/telegram-web-app.js"></script>
+<script src="./src/tg-viewport.js"></script>
 <style>
-  :root{
-    --bg1:#1b1f29; --bg2:#2a2f3a; --panel:#2e323d; --accent:#c6934b;
-    --light:#e8d2ad; --dark:#7b5a2f; --red:#8b2d2d; --white:#f5f2ea;
-  }
   *{box-sizing:border-box}
-  html,body{height:100%;margin:0;background:linear-gradient(180deg,#151923,#1a2030 40%,#0f1320);}
-  body{font:16px/1.4 -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Inter,Arial,sans-serif;color:#eef2ff;display:flex;justify-content:center;align-items:center;overflow:hidden}
-  .wrap{width:min(100vw,900px);padding:16px}
-  .card{
-    background: radial-gradient(1200px 600px at 50% -200px, rgba(255,255,255,.04), transparent 60%) , linear-gradient(180deg,#2c303b,#242833);
-    border-radius:18px; box-shadow:0 20px 50px rgba(0,0,0,.45), inset 0 1px 0 rgba(255,255,255,.04);
-    border:1px solid rgba(255,255,255,.06);
-  }
   .header{display:flex;gap:12px;align-items:center;padding:14px 16px;border-bottom:1px solid rgba(255,255,255,.06)}
   .brand{font-weight:700;letter-spacing:.4px}
   .screens{padding:16px}
@@ -37,22 +28,20 @@
   .select, .input{
     width:100%; padding:10px 12px; border-radius:10px; border:1px solid rgba(255,255,255,.08); background:#333846; color:#e9edf6;
   }
-  .boardContainer{aspect-ratio:1/1; width:100%; max-width:680px; margin:0 auto; user-select:none; -webkit-user-select:none; touch-action:none}
-  canvas{width:100%;height:100%;display:block;border-radius:16px;box-shadow:inset 0 0 0 1px rgba(255,255,255,.08)}
-  .toolbar{display:flex;gap:8px;flex-wrap:wrap;align-items:center;margin-top:12px}
+  canvas.board{display:block;border-radius:16px;box-shadow:inset 0 0 0 1px rgba(255,255,255,.08)}
   .meta{margin-top:10px;font-size:14px;opacity:.9;display:grid;grid-template-columns:1fr 1fr;gap:6px}
   .hidden{display:none}
 </style>
 </head>
 <body>
-<div id="app" class="wrap">
-  <div class="card">
-    <div class="header">
-      <div class="brand">Русские шашки</div>
-      <div style="flex:1"></div>
-      <button id="toMenu" class="btn secondary hidden">Настройки</button>
-    </div>
+<div id="app" class="app-root">
+  <header class="header">
+    <div class="brand">Русские шашки</div>
+    <div style="flex:1"></div>
+    <button id="toMenu" class="btn secondary hidden">Настройки</button>
+  </header>
 
+  <section class="main">
     <div id="screenMenu" class="screens">
       <div class="row">
         <div class="col">
@@ -95,23 +84,30 @@
     </div>
 
     <div id="screenGame" class="screens hidden">
-      <div class="boardContainer"><canvas id="board" class="board" width="1024" height="1024"></canvas></div>
-      <div class="toolbar">
-        <button id="btnUndo" class="btn secondary">Отменить</button>
-        <button id="btnHint" class="btn secondary">Подсказка</button>
-        <button id="btnRestart" class="btn">Сдаться / Новая</button>
-        <div style="flex:1"></div>
-        <label class="switch"><input id="toggleSfx" type="checkbox" checked/> Звуки</label>
+      <div class="board-wrap">
+        <canvas id="board" class="board" width="1024" height="1024"></canvas>
       </div>
-      <div class="meta">
-        <div>Ход: <b id="turnLabel">—</b></div>
-        <div>Статус: <b id="statusLabel">—</b></div>
-      </div>
+      <aside class="side-panel">
+        <div class="meta">
+          <div>Ход: <b id="turnLabel">—</b></div>
+          <div>Статус: <b id="statusLabel">—</b></div>
+        </div>
+      </aside>
     </div>
-</div>
+  </section>
+
+  <footer class="footer">
+    <div class="controls">
+      <button id="btnUndo" class="btn secondary">Отменить</button>
+      <button id="btnHint" class="btn secondary">Подсказка</button>
+      <button id="btnRestart" class="btn">Сдаться / Новая</button>
+      <label class="switch"><input id="toggleSfx" type="checkbox" checked/> Звуки</label>
+    </div>
+  </footer>
 </div>
 
 <script src="./src/gestures-guard.js"></script>
+<script src="./src/board-resize.js"></script>
 <script type="module">
   import { initAudio, playMove as playMoveSfx } from './src/audio.js?v=2';
   import { showEndModal } from './src/modal.js?v=1';

--- a/src/board-resize.js
+++ b/src/board-resize.js
@@ -1,0 +1,25 @@
+(function(){
+  const wrap = document.querySelector('.board-wrap');
+  const board = document.querySelector('.board');
+  if (!wrap || !board) return;
+
+  const ro = new ResizeObserver(entries => {
+    const cr = entries[0].contentRect;
+    const size = Math.floor(Math.min(cr.width, cr.height));
+    // Делаем реальный квадрат пиксель-в-пиксель, чтобы не плыли линии
+    wrap.style.setProperty('width', size + 'px');
+    wrap.style.setProperty('height', size + 'px');
+    board.style.setProperty('width', size + 'px');
+    board.style.setProperty('height', size + 'px');
+  });
+  ro.observe(wrap);
+
+  // Первичная установка
+  const init = () => {
+    const rect = wrap.getBoundingClientRect();
+    const size = Math.floor(Math.min(rect.width, rect.height));
+    wrap.style.width = wrap.style.height = size + 'px';
+    board.style.width = board.style.height = size + 'px';
+  };
+  window.addEventListener('load', init, { once:true });
+})();

--- a/src/tg-viewport.js
+++ b/src/tg-viewport.js
@@ -1,0 +1,22 @@
+(function(){
+  const setVH = () => {
+    // Если в Telegram доступна стабильная высота — используем её
+    const tg = window.Telegram && Telegram.WebApp;
+    const h = tg?.viewportStableHeight || tg?.viewportHeight || window.innerHeight;
+    // Переводим в "единицу vh" для CSS переменной
+    document.documentElement.style.setProperty('--vh', (h/100) + 'px');
+  };
+  setVH();
+  // Telegram шлёт события изменения Viewport — подпишемся
+  if (window.Telegram && Telegram.WebApp) {
+    try { Telegram.WebApp.onEvent('viewportChanged', setVH); } catch(e){}
+    try { Telegram.WebApp.expand(); } catch(e){}
+    // Насыщаем тему (опционально, если используете TG тему)
+    try {
+      const theme = Telegram.WebApp.themeParams || {};
+      if (theme.bg_color) document.documentElement.style.setProperty('--bg', theme.bg_color);
+    } catch(e){}
+  }
+  // На всякий случай — реагируем и на ресайзы браузера
+  window.addEventListener('resize', setVH);
+})();

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,9 @@
 :root{
+  --vh: 1dvh; /* переопределим из JS телеги */
+  --safe-top: env(safe-area-inset-top, 0px);
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-left: env(safe-area-inset-left, 0px);
+  --safe-right: env(safe-area-inset-right, 0px);
   --bg:#0f172a; --panel:#111827; --text:#e5e7eb;
   --board-light:#d6b07b; --board-dark:#6b4a32;
   --piece-light:#fff6e8; --piece-dark:#8b1e1e;
@@ -18,11 +23,57 @@ html, body {
   height: 100%;
   overflow: hidden;
   overscroll-behavior: none;
-  -webkit-overflow-scrolling: auto;
+  background: var(--bg, #0f172a);
 }
 #app, .app-root {
   position: fixed;
   inset: 0;
+  padding: calc(var(--safe-top) + 8px) calc(var(--safe-right) + 12px)
+           calc(var(--safe-bottom) + 12px) calc(var(--safe-left) + 12px);
+  display: grid;
+  grid-template-rows: auto 1fr auto; /* header / content / footer */
+  gap: 8px;
+}
+
+/* Центральная зона с доской и боковыми панелями */
+.main {
+  min-height: calc(100 * var(--vh));
+  display: grid;
+  grid-template-columns: 1fr;       /* мобильный вид — один столбец */
+  grid-template-rows: 1fr;
+  place-items: center;
+}
+
+/* Вьюшка доски — квадратная, растягивается по минимуму из W/H */
+.board-wrap {
+  position: relative;
+  width: min(100%, 100vmin);
+  height: min(100%, 100vmin);
+  /* Пересчёт через inline-style из JS даст точный пиксельный квадрат */
+}
+
+/* Сама доска занимает 100% обёртки */
+.board {
+  position: absolute;
+  inset: 0;
+  aspect-ratio: 1 / 1;
+}
+
+/* Кнопки и панели — адаптивные от ширины экрана */
+.controls {
+  display: grid;
+  grid-auto-flow: column;
+  gap: 8px;
+}
+.controls button { font-size: clamp(12px, 1.6vw, 16px); }
+
+/* На планшете/десктопе — раскладка 2 колонки: доска + панель */
+@media (min-width: 820px) and (orientation: landscape) {
+  .main {
+    grid-template-columns: 1fr 320px;
+    align-items: center;
+  }
+  .side-panel { height: 100%; overflow: auto; }
 }
 .board, .board * {
   touch-action: none;


### PR DESCRIPTION
## Summary
- handle Telegram viewport height and theme parameters
- resize board to exact square via ResizeObserver
- document safe-area and responsive layout for WebApp

## Testing
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c664b3778833194a316d18918622b