### PR TITLE
Stabilize layout and board sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,11 +38,19 @@
   <header class="header">
     <div class="brand">Русские шашки</div>
     <div style="flex:1"></div>
-    <button id="toMenu" class="btn secondary hidden">Настройки</button>
+    <button id="btnSettings" class="btn secondary hidden">Настройки</button>
   </header>
 
-  <main class="main">
-    <div id="screenMenu" class="screens">
+  <main class="content">
+    <section class="game">
+      <div class="board-wrap"><div class="board"><canvas id="board" width="1024" height="1024"></canvas></div></div>
+      <div class="meta">
+        <div>Ход: <b id="turnLabel">—</b></div>
+        <div>Статус: <b id="statusLabel">—</b></div>
+      </div>
+    </section>
+
+    <section class="settings" hidden>
       <div class="row">
         <div class="col">
           <h3>Игра</h3>
@@ -81,21 +89,7 @@
           <button id="startGame" class="btn">Новая игра</button>
         </div>
       </div>
-    </div>
-
-    <div id="screenGame" class="screens hidden">
-      <div class="board-wrap">
-        <div class="board">
-          <canvas id="board" width="1024" height="1024"></canvas>
-        </div>
-      </div>
-      <aside class="side-panel">
-        <div class="meta">
-          <div>Ход: <b id="turnLabel">—</b></div>
-          <div>Статус: <b id="statusLabel">—</b></div>
-        </div>
-      </aside>
-    </div>
+    </section>
   </main>
 
   <footer class="footer">
@@ -103,7 +97,6 @@
       <button id="btnUndo" class="btn secondary">Отменить</button>
       <button id="btnHint" class="btn secondary">Подсказка</button>
       <button id="btnRestart" class="btn">Сдаться / Новая</button>
-      <label class="switch"><input id="toggleSfx" type="checkbox" checked/> Звуки</label>
     </div>
   </footer>
 </div>
@@ -137,9 +130,9 @@ const DIRS = [[1,1],[1,-1],[-1,1],[-1,-1]];
 
 /* =============== Инициализация =============== */
 const UI = {
-  menu:document.getElementById('screenMenu'),
-  game:document.getElementById('screenGame'),
-  toMenu:document.getElementById('toMenu'),
+  settings:document.querySelector('.settings'),
+  game:document.querySelector('.game'),
+  settingsBtn:document.getElementById('btnSettings'),
   board:document.getElementById('board'),
   turn:document.getElementById('turnLabel'),
   status:document.getElementById('statusLabel'),
@@ -150,7 +143,6 @@ const UI = {
   yourColor:document.getElementById('yourColor'),
   sfxOn:document.getElementById('sfxOn'),
   theme:document.getElementById('themeSelect'),
-  tSfx:document.getElementById('toggleSfx'),
   undo:document.getElementById('btnUndo'), hint:document.getElementById('btnHint'), restart:document.getElementById('btnRestart'),
   // элементы для панели тестов удалены
 };
@@ -192,7 +184,6 @@ UI.sfxOn.checked = savedSettings.sfx ?? true;
 UI.theme.value = savedSettings.theme || 'classic';
 document.body.classList.add('theme-'+UI.theme.value);
 updateThemeColors();
-UI.tSfx.checked = UI.sfxOn.checked;
 
 function saveSettings(){
   localStorage.setItem('settings', JSON.stringify({
@@ -201,7 +192,7 @@ function saveSettings(){
   }));
 }
 
-UI.sfxOn.addEventListener('change', ()=>{ UI.tSfx.checked = UI.sfxOn.checked; saveSettings(); });
+UI.sfxOn.addEventListener('change', saveSettings);
 UI.theme.addEventListener('change', ()=>{
   document.body.classList.remove('theme-classic','theme-walnut','theme-graphite');
   document.body.classList.add('theme-'+UI.theme.value);
@@ -347,7 +338,7 @@ function playMove(state, move, {silent=false}={}){
     history:[...state.history, {move, board:state.board}],
   };
   if(!silent){
-    if(window.AudioAPI && (UI.sfxOn.checked && UI.tSfx.checked)) window.AudioAPI.playMove();
+    if(window.AudioAPI && UI.sfxOn.checked) window.AudioAPI.playMove();
   }
   const must = state.mustCapture && captures.length>0;
   if(must){
@@ -368,7 +359,7 @@ function playMove(state, move, {silent=false}={}){
     State.status = (next.turn===LIGHT? "Белые":"Чёрные")+" без ходов. Победа!";
     if(window.AudioAPI){
       const result = (State.humanColor === next.turn)? 'lose':'win';
-      window.AudioAPI.showEndModal({result, onNew:newGameFromMenu, onSettings:()=>toScreen('menu')});
+      window.AudioAPI.showEndModal({result, onNew:newGameFromMenu, onSettings:showSettings});
     }
   }else{
     State.status = "Идёт игра";
@@ -486,15 +477,21 @@ function newGameFromMenu(){
   State.humanColor = UI.yourColor.value==="white"? LIGHT: DARK;
   State.aiDepth = parseInt(UI.level.value,10);
   State.selectable=[]; State.movesCache=null; State.dragging=null; State.hover=null;
-  UI.tSfx.checked = UI.sfxOn.checked;
   if(State.mode==="ai" && State.humanColor!==State.turn){ setTimeout(thinkAI, 200); }
-  toScreen('game'); syncUI();
+  showGame();
+  syncUI();
 }
-function toScreen(which){
-  const toGame = which==='game';
-  UI.menu.classList.toggle('hidden', toGame);
-  UI.game.classList.toggle('hidden', !toGame);
-  UI.toMenu.classList.toggle('hidden', !toGame);
+function showGame(){
+  UI.game.hidden=false;
+  UI.settings.hidden=true;
+  UI.settingsBtn.classList.remove('hidden');
+  if(window.sizeBoard) sizeBoard();
+}
+function showSettings(){
+  UI.game.hidden=true;
+  UI.settings.hidden=false;
+  UI.settingsBtn.classList.add('hidden');
+  if(window.sizeBoard) sizeBoard();
 }
 UI.undo.addEventListener('click', ()=>{
   if(!State.history.length) return;
@@ -512,11 +509,10 @@ UI.hint.addEventListener('click', ()=>{
   State.status="Подсказка: выделен лучший ход";
   draw();
 });
-UI.restart.addEventListener('click', ()=>{ toScreen('menu'); });
-UI.tSfx.addEventListener('change', e=>{ UI.sfxOn.checked = e.target.checked; saveSettings(); });
+UI.restart.addEventListener('click', showSettings);
 UI.start.addEventListener('click', newGameFromMenu);
-UI.toMenu.addEventListener('click', ()=>toScreen('menu'));
-(function boot(){ draw(); })();
+UI.settingsBtn.addEventListener('click', showSettings);
+(function boot(){ draw(); showSettings(); })();
 
 </script>
 <script src="./src/board-layout.js"></script>

--- a/src/board-layout.js
+++ b/src/board-layout.js
@@ -1,39 +1,30 @@
 (function(){
   const $ = s => document.querySelector(s);
-  const app = $('#app');
-  const main = $('.main');
-  const header = $('.header');
-  const footer = $('.footer');
+  const content = $('.content');
   const wrap = $('.board-wrap');
   const board = $('.board');
-
-  if (!app || !main || !wrap || !board) return;
+  if (!content || !wrap || !board) return;
 
   function sizeBoard(){
-    // Доступная область внутри main
-    const appRect = app.getBoundingClientRect();
-    const headH = header ? header.getBoundingClientRect().height : 0;
-    const footH = footer ? footer.getBoundingClientRect().height : 0;
-
-    // Внутренние паддинги app уже учтены браузером, поэтому ориентируемся по main:
-    const mainRect = main.getBoundingClientRect();
-    const availW = Math.floor(mainRect.width);
-    const availH = Math.floor(mainRect.height);
-
-    // Квадрат — минимум из сторон
-    const size = Math.max(120, Math.min(availW, availH)); // нижний предел 120px, чтобы не схлопывалось
+    // Высота доступной зоны контента (между header и footer)
+    const rect = content.getBoundingClientRect();
+    const availW = Math.floor(rect.width);
+    const availH = Math.floor(rect.height);
+    const size = Math.max(160, Math.min(availW, availH)); // не даём схлопнуться
     wrap.style.width = size + 'px';
     wrap.style.height = size + 'px';
     board.style.width = size + 'px';
     board.style.height = size + 'px';
   }
 
+  window.sizeBoard = sizeBoard;
+
   const ro = new ResizeObserver(sizeBoard);
-  ro.observe(main);
+  ro.observe(content);
   ro.observe(wrap);
 
   window.addEventListener('load', sizeBoard, { once:true });
-  window.addEventListener('orientationchange', () => setTimeout(sizeBoard, 50));
-  document.addEventListener('visibilitychange', () => { if (!document.hidden) setTimeout(sizeBoard, 50); });
+  window.addEventListener('orientationchange', () => setTimeout(sizeBoard, 60));
+  document.addEventListener('visibilitychange', () => { if (!document.hidden) setTimeout(sizeBoard, 60); });
 })();
 

--- a/styles.css
+++ b/styles.css
@@ -1,10 +1,10 @@
 :root{
-  --vh: 1dvh; /* будет переопределено из JS */
+  --vh: 1dvh; /* переопределяется из JS */
   --safe-top: env(safe-area-inset-top, 0px);
   --safe-right: env(safe-area-inset-right, 0px);
   --safe-bottom: env(safe-area-inset-bottom, 0px);
   --safe-left: env(safe-area-inset-left, 0px);
-  --bg:#0f172a;
+  --bg: #0f172a;
   --panel:#111827; --text:#e5e7eb;
   --board-light:#d6b07b; --board-dark:#6b4a32;
   --piece-light:#fff6e8; --piece-dark:#8b1e1e;
@@ -27,27 +27,31 @@ html, body {
   background: var(--bg, #0f172a);
 }
 #app.app-root{
-  position:fixed;
-  inset:0;
-  padding: calc(var(--safe-top) + 8px) calc(var(--safe-right) + 12px)
-           calc(var(--safe-bottom) + 12px) calc(var(--safe-left) + 12px);
+  position:fixed; inset:0;
   display:grid;
-  grid-template-rows:auto 1fr auto; /* header / main / footer */
+  grid-template-rows:auto 1fr auto; /* header / content / footer */
+  padding: calc(var(--safe-top) + 6px) calc(var(--safe-right) + 10px)
+           calc(var(--safe-bottom) + 10px) calc(var(--safe-left) + 10px);
   gap:8px;
   height:100%; /* будет переписано инлайн через JS под стабильную высоту TG */
 }
 
-/* Центральная зона с доской и боковыми панелями */
-.main{
-  min-height:100%;
+/* Контентная область: НИКАКИХ фиксированных высот! */
+.content{
+  min-height:0; /* разрешить ребёнку ужиматься */
   display:grid;
-  grid-template-columns:1fr;     /* мобильный — одна колонка */
-  grid-auto-rows:minmax(0,1fr);  /* важно: чтобы вложенные элементы могли ужиматься */
-  place-items:center;
-  gap:12px;
+  grid-template-columns: 1fr;
+  grid-auto-rows:minmax(0,1fr);
 }
 
-/* Вьюшка доски — квадратная, растягивается по минимуму из W/H */
+/* Игровой экран */
+.game{
+  min-height:0;
+  display:grid;
+  place-items:center;
+}
+
+/* Квадратная обёртка. Точные px проставит JS. */
 .board-wrap{
   position:relative;
   width:100%;
@@ -56,13 +60,23 @@ html, body {
   max-height:100%;
 }
 
-/* Сама доска занимает 100% обёртки */
 .board{
-  position:absolute;
-  inset:0;
+  position:absolute; inset:0;
   aspect-ratio:1/1;
 }
 .board canvas{width:100%;height:100%;display:block;}
+
+/* Экран настроек прокручиваемый, с отступом под футер */
+.settings{
+  min-height:0;
+  overflow:auto;
+  padding-bottom: calc(72px + var(--safe-bottom)); /* запас под высоту футера */
+}
+
+/* Футер всегда внизу макета, БЕЗ position:fixed поверх контента */
+.footer{
+  min-height:56px;
+}
 
 /* Кнопки и панели — адаптивные от ширины экрана */
 .controls {
@@ -72,13 +86,10 @@ html, body {
 }
 .controls button{ font-size: clamp(12px, 1.6vw, 16px); }
 
-/* На планшете/десктопе — раскладка 2 колонки: доска + панель */
 @media (min-width:820px) and (orientation:landscape){
-  .main{
-    grid-template-columns:minmax(0,1fr) 320px; /* доска + панель */
-    align-items:center;
+  .content{
+    grid-template-columns:minmax(0,1fr) 340px; /* игра + панель/настройки */
   }
-  .side-panel{ height:100%; overflow:auto; }
 }
 .board, .board *{ touch-action:none; }
 body{ background:var(--bg); color:var(--text); }


### PR DESCRIPTION
## Summary
- Rebuild app shell with unified header/content/footer structure and single footer control block
- Add adaptive CSS grid with safe-area support and scrollable settings panel
- Implement board sizing logic and screen toggles for reliable game/settings transitions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c6c16a3e083319be13c51d887a0a8