### PR TITLE
Center game board in available viewport

### DIFF
--- a/src/board-layout.js
+++ b/src/board-layout.js
@@ -1,20 +1,31 @@
 // src/board-layout.js
 (function(){
-  const wrap = document.querySelector('.board-wrap');
+  const host  = document.querySelector('#view-game .game-grid');  // грид-контейнер
+  const wrap  = document.querySelector('.board-wrap');
   const board = document.querySelector('.board');
-  const host  = document.querySelector('#view-game .game-grid');
-  if (!wrap || !board || !host) return;
+  if (!host || !wrap || !board) return;
 
   function sizeBoard(){
+    // Доступная область между header и footer — это сам .game-grid:
     const r = host.getBoundingClientRect();
-    const size = Math.max(180, Math.min(Math.floor(r.width), Math.floor(r.height)));
-    wrap.style.width = wrap.style.height = size + 'px';
-    board.style.width = board.style.height = size + 'px';
+    // Отведём небольшой «воздух» под подписи/статус (на телефонах):
+    const padding = Math.min(24, Math.floor(r.height * 0.04));
+    const availW = Math.max(0, Math.floor(r.width)  - padding*2);
+    const availH = Math.max(0, Math.floor(r.height) - padding*2);
+
+    const size = Math.max(180, Math.min(availW, availH)); // квадрат, но не меньше 180px
+    wrap.style.width  = size + 'px';
+    wrap.style.height = size + 'px';
+    board.style.width  = size + 'px';
+    board.style.height = size + 'px';
   }
+
   const ro = new ResizeObserver(sizeBoard);
   ro.observe(host);
   ro.observe(wrap);
-  window.addEventListener('orientationchange', () => setTimeout(sizeBoard, 60));
+
   window.addEventListener('load', sizeBoard, { once:true });
+  window.addEventListener('orientationchange', () => setTimeout(sizeBoard, 60));
   window.addEventListener('reflow-board', sizeBoard);
 })();
+

--- a/styles.css
+++ b/styles.css
@@ -38,8 +38,10 @@ html, body{
 .logo{ font-weight:800; letter-spacing:.2px; }
 .btn-ghost{ background:rgba(255,255,255,.06); border:0; color:var(--text); padding:8px 12px; border-radius:12px; }
 
-/* Контент */
-.content{ min-height:0; }
+/* Контентный экран */
+.content{
+  min-height:0;
+}
 .view{ width:100%; height:100%; }
 .view[hidden]{ display:none !important; }
 
@@ -53,21 +55,42 @@ html, body{
 .card-head h2{ margin:0; font-size:16px; }
 .card-body{ padding:12px; min-height:0; }
 
-/* Игра: сетка */
-.game-card{ height:100%; }
-.game-grid{
-  display:grid; gap:12px; min-height:0;
-  grid-template-columns:1fr;
-  grid-auto-rows:minmax(0,1fr);
-  place-items:center;
-}
-@media (min-width:820px) and (orientation:landscape){
-  .game-grid{ grid-template-columns:minmax(0,1fr) 320px; align-items:center; }
+/* Карточка игры занимает всю высоту доступной зоны */
+.game-card{
+  height:100%;
+  display:flex;
+  flex-direction:column;
+  min-height:0;
 }
 
-/* Доска */
+/* Основная зона игры: грид, который ЦЕНТРИРУЕТ содержимое */
+.game-grid{
+  display:grid;
+  /* 1) два ряда: доска и справа/снизу панель статуса (авто) */
+  grid-template-columns: 1fr;
+  grid-template-rows: auto auto;
+  gap:12px;
+  min-height:0;
+
+  /* 2) ключ: центрирование по обеим осям */
+  place-items:center;        /* центр по горизонтали */
+  place-content:center;      /* центр по вертикали */
+}
+
+/* На планшете справа может быть панель — центрирование сохраняем */
+@media (min-width:820px) and (orientation:landscape){
+  .game-grid{
+    grid-template-columns: minmax(0,1fr) 320px;
+    grid-template-rows: auto;
+    place-items:center;
+    place-content:center;    /* важно не убирать */
+  }
+}
+
+/* Обёртка и доска: размеры проставляет JS, позиционирование абсолютом */
 .board-wrap{
-  position:relative; width:100%; height:100%;
+  position:relative;
+  width:100%; height:100%;
   max-width:100%; max-height:100%;
 }
 .board{ position:absolute; inset:0; aspect-ratio:1/1; }
@@ -79,10 +102,13 @@ html, body{
 .piece.light{ background:radial-gradient(ellipse at 35% 30%, #fff, var(--piece-light)); }
 .piece.dark{  background:radial-gradient(ellipse at 35% 30%, #b00000, var(--piece-dark)); }
 
-/* Панель справа */
+/* Панель статуса не должна «толкать» сетку вверх */
 .side-panel{
-  width:100%; background:rgba(255,255,255,.03);
-  border-radius:12px; padding:12px;
+  width:100%;
+  justify-self:center;
+  background:rgba(255,255,255,.03);
+  border-radius:12px;
+  padding:12px;
 }
 .stat{ color:var(--muted); margin:6px 0; }
 .stat b{ color:var(--text); }


### PR DESCRIPTION
## Summary
- Center game grid vertically and horizontally using CSS grid and ensure status panel doesn't shift it
- Recalculate board size based on grid container to keep square board with padding
- Confirm early viewport sizing script for Telegram WebApp

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/StarCheckers/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689c83e99e288331b01610bfa764d127