### PR TITLE
Add safe top buffer for Telegram header and board sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 <link rel="stylesheet" href="./styles.css?v=1">
 <script src="https://telegram.org/js/telegram-web-app.js"></script>
 <script src="./src/tg-viewport.js"></script>
+<script src="./src/tg-header-buffer.js"></script>
 <script src="./src/gestures-guard.js"></script>
 </head>
 <body>

--- a/src/board-center.js
+++ b/src/board-center.js
@@ -5,19 +5,11 @@
   if (!stage || !wrap || !board) return;
 
   function sizeBoard(){
-    // Размер доступной сцены (между appbar и footer)
     const r = stage.getBoundingClientRect();
-
-    // Защита от iOS всплывающих панелей: делаем небольшой внутренний запас
     const pad = Math.min(24, Math.floor(Math.min(r.width, r.height) * 0.04));
-
     const availW = Math.max(0, Math.floor(r.width)  - pad*2);
     const availH = Math.max(0, Math.floor(r.height) - pad*2);
-
-    // Квадратный размер: максимум, но не меньше 200px
     const size = Math.max(200, Math.min(availW, availH));
-
-    // Проставляем точные px — так не будет артефактов сетки
     wrap.style.inlineSize = size + 'px';
     wrap.style.blockSize  = size + 'px';
     board.style.inlineSize = '100%';
@@ -28,12 +20,8 @@
   const ro = new ResizeObserver(sizeBoard);
   ro.observe(stage);
 
-  // Гарантированные перерасчёты
   window.addEventListener('load', sizeBoard, { once:true });
   window.addEventListener('orientationchange', () => setTimeout(sizeBoard, 80));
-  document.addEventListener('visibilitychange', () => { if (!document.hidden) setTimeout(sizeBoard, 80); });
-
-  // Фоллбек от редких «прыжков» iOS после открытия
-  setTimeout(sizeBoard, 120);
-  setTimeout(sizeBoard, 300);
+  window.addEventListener('reflow-board', sizeBoard);
+  setTimeout(sizeBoard, 120); setTimeout(sizeBoard, 300);
 })();

--- a/src/tg-header-buffer.js
+++ b/src/tg-header-buffer.js
@@ -1,0 +1,27 @@
+(function(){
+  const ua = navigator.userAgent.toLowerCase();
+  const tg = (window.Telegram && Telegram.WebApp) ? Telegram.WebApp : null;
+
+  // Базовые эвристики высоты нативной шапки
+  let header = 56; // Android/общий случай
+  if (/iphone|ipad|ipod/.test(ua)) header = 64;        // iOS: шапка выше
+  if (!tg) header = 0;                                  // Обычный браузер — нативной шапки TG нет
+  if (tg && (tg.platform === 'tdesktop' || tg.platform === 'web')) header = 0;
+
+  // Установим переменную
+  document.documentElement.style.setProperty('--tg-header', header + 'px');
+
+  // Пересчёт при изменении вьюпорта от Telegram
+  const refresh = () => {
+    // Если Telegram разворачивает webview (expand), шапка может визуально «сжаться» — оставим минимально 48–56
+    const minHeader = /iphone|ipad|ipod/.test(ua) ? 60 : 48;
+    const h = Math.max(minHeader, header);
+    document.documentElement.style.setProperty('--tg-header', h + 'px');
+    // Форс-рефлоу доски (если есть слушатель)
+    window.dispatchEvent(new Event('reflow-board'));
+  };
+
+  try { tg && tg.onEvent && tg.onEvent('viewportChanged', refresh); } catch(e){}
+  // Подстраховка: пересчитать чуть позже после загрузки
+  setTimeout(refresh, 150);
+})();

--- a/styles.css
+++ b/styles.css
@@ -9,10 +9,13 @@
 
   /* Телеграм/браузер высота */
   --vh: 1dvh;
+  /* уже есть safe-area; добавим буфер шапки TG */
   --safe-top: env(safe-area-inset-top, 0px);
   --safe-right: env(safe-area-inset-right, 0px);
   --safe-bottom: env(safe-area-inset-bottom, 0px);
   --safe-left: env(safe-area-inset-left, 0px);
+  --tg-header: 56px;
+  --top-safe-buffer: calc(var(--safe-top) + var(--tg-header));
 }
 
 html, body{
@@ -21,27 +24,27 @@ html, body{
   font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial, "Helvetica Neue";
 }
 
-/* Корень: фиксируем реальные границы и учитываем safe-area */
+/* Корневой контейнер приложения */
 #app.app-root{
   position:fixed; inset:0;
   display:grid; gap:12px;
-  grid-template-rows:auto 1fr auto; /* appbar / stage / footer */
-  padding: calc(var(--safe-top) + 8px)
+  grid-template-rows:auto 1fr auto;          /* appbar / stage / footer */
+  padding: calc(var(--top-safe-buffer) + 8px)
            calc(var(--safe-right) + 12px)
            calc(var(--safe-bottom) + 12px)
            calc(var(--safe-left) + 12px);
 }
 
-/* Верхняя панель — без фиксированных высот */
-.appbar{ display:flex; align-items:center; justify-content:space-between; gap:8px; }
+/* Верхняя панель НЕ должна иметь отрицательных маргинов и фиксированных позиций */
+.appbar{ position:relative; z-index:1; display:flex; align-items:center; justify-content:space-between; gap:8px; }
 .logo{ font-weight:800; letter-spacing:.2px; }
 .btn-ghost{ background:rgba(255,255,255,.06); border:0; color:var(--text); padding:8px 12px; border-radius:12px; }
 
-/* Сцена (между appbar и footer) — это ЕДИНСТВЕННОЕ место, от которого считаем центр */
+/* Сцена между appbar и footer — от неё считаем центрирование */
 .stage{
   min-height:0;
-  block-size: 100%;
-  overflow: clip;           /* без скролла сцены */
+  block-size:100%;
+  overflow:clip;
 }
 .view{ inline-size:100%; block-size:100%; }
 .view[hidden]{ display:none !important; }


### PR DESCRIPTION
## Summary
- add CSS variables and padding to keep app content below Telegram header
- compute Telegram header height in `tg-header-buffer.js` and update CSS custom property
- center the game board based on stage size and reflow on viewport changes

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c923a4e5c8331a46955ba62818131