### PR TITLE
Center board stack with caption sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,10 +28,10 @@
     <section id="view-game" class="view">
       <div class="game-center">
         <div class="board-wrap"><div class="board"><canvas id="board" width="1024" height="1024"></canvas></div></div>
-        <aside class="side-panel" aria-hidden="true">
+        <div class="board-caption" id="board-caption">
           <div class="stat"><span>Ход:</span> <b id="turn">—</b></div>
           <div class="stat"><span>Статус:</span> <b id="status">—</b></div>
-        </aside>
+        </div>
       </div>
     </section>
 
@@ -80,7 +80,7 @@
       <button data-action="new"  class="btn btn-primary">Сдаться / Новая</button>
     </div>
   </footer>
-<script src="./src/board-center.js"></script>
+<script src="./src/board-fit-with-caption.js"></script>
 <script type="module" src="./index.js"></script>
 <script type="module">
   import { initAudio, playMove as playMoveSfx } from './src/audio.js?v=2';

--- a/src/board-fit-with-caption.js
+++ b/src/board-fit-with-caption.js
@@ -1,0 +1,51 @@
+(function(){
+  const stage   = document.getElementById('stage');
+  const wrap    = document.querySelector('.board-wrap');
+  const board   = document.querySelector('.board');
+  const caption = document.getElementById('board-caption');
+  if (!stage || !wrap || !board || !caption) return;
+
+  const outerHeight = (el) => {
+    const cs = getComputedStyle(el);
+    const mt = parseFloat(cs.marginTop)  || 0;
+    const mb = parseFloat(cs.marginBottom)|| 0;
+    return Math.ceil(el.getBoundingClientRect().height + mt + mb);
+  };
+
+  function sizeBoard(){
+    const r = stage.getBoundingClientRect();
+
+    // Запас от краёв, чтобы стек «дышал»
+    const pad = Math.min(24, Math.floor(Math.min(r.width, r.height) * 0.04));
+
+    // Текущая высота подписи (с учётом переноса строк на узких экранах)
+    const capH = outerHeight(caption);
+
+    // Доступные размеры под квадрат ДОСКИ: вся сцена минус подпись и отступы
+    const availW = Math.max(0, Math.floor(r.width)  - pad*2);
+    const availH = Math.max(0, Math.floor(r.height) - pad*2 - capH);
+
+    // Квадратный размер. Не меньше минимального, но не вылезаем под подпись.
+    const size = Math.max(200, Math.min(availW, availH));
+
+    wrap.style.inlineSize = size + 'px';
+    wrap.style.blockSize  = size + 'px';
+    board.style.inlineSize = '100%';
+    board.style.blockSize  = '100%';
+  }
+
+  // Следим за изменениями сцены и подписи (перенос текста, смена языка и т.п.)
+  const ro1 = new ResizeObserver(sizeBoard);
+  ro1.observe(stage);
+  const ro2 = new ResizeObserver(sizeBoard);
+  ro2.observe(caption);
+
+  // Гарантированные перерасчёты
+  window.addEventListener('load', sizeBoard, { once:true });
+  window.addEventListener('orientationchange', () => setTimeout(sizeBoard, 80));
+  window.addEventListener('reflow-board', sizeBoard);
+
+  // Небольшие подстраховки от iOS «прыжков»
+  setTimeout(sizeBoard, 120);
+  setTimeout(sizeBoard, 300);
+})();

--- a/styles.css
+++ b/styles.css
@@ -49,24 +49,23 @@ html, body{
 .view{ inline-size:100%; block-size:100%; }
 .view[hidden]{ display:none !important; }
 
-/* Контейнер центрирования: flex-центр по обеим осям */
+/* Центрирование всего стека (доска + подпись) */
 .game-center{
-  inline-size: 100%;
-  block-size: 100%;
-  display:flex;
-  align-items:center;       /* вертикальное центрирование */
-  justify-content:center;   /* горизонтальное */
-  position:relative;
-  overflow:visible;
+  inline-size:100%;
+  block-size:100%;
+  display:grid;
+  grid-template-rows:auto auto;
+  justify-items:center;
+  align-content:center;
+  row-gap:12px;
 }
 
-/* Обёртка и доска: размер задаёт JS, aspect 1/1 */
+/* Обёртка доски: размер задаёт JS */
 .board-wrap{
   position:relative;
-  display:block;
   aspect-ratio:1/1;
-  max-inline-size: 100%;
-  max-block-size: 100%;
+  max-inline-size:100%;
+  max-block-size:100%;
 }
 .board{
   position:absolute; inset:0;
@@ -75,16 +74,16 @@ html, body{
 }
 .board canvas{ inline-size:100%; block-size:100%; display:block; }
 
-/* Сайд-панель не влияет на центрирование */
-.side-panel{
-  position:absolute; top:0; right:0;
-  background:rgba(255,255,255,.03);
+/* Подпись под доской — читабельная, не обрезается */
+.board-caption{
+  padding:10px 12px;
+  background:rgba(255,255,255,.06);
   border-radius:12px;
-  padding:12px;
+  max-inline-size: min(92vw, 520px);
+  color:var(--text);
 }
-.stat{ color:var(--text); font-size:14px; margin:6px 0; }
-.stat span{ opacity:.7; }
-.stat b{ font-weight:600; }
+.board-caption .stat{ line-height:1.2; margin:2px 0; opacity:.9; }
+.board-caption .stat b{ opacity:1; }
 
 /* Низ: одна строка, не перекрывает сцену */
 .footer{ min-height:60px; }


### PR DESCRIPTION
## Summary
- Replace side panel with caption container after the board
- Center board and caption with grid layout and prevent clipping
- Size board dynamically accounting for caption height

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c94b270b48331a3cb9810801f723a