### PR TITLE
chore(render): deploy as Static Site + SPA fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ npm run build
 npm run preview
 ```
 
+## Deploy on Render
+
+Build Command: `npm ci && npm run build`
+
+Publish Directory: `dist`
+
+Environment: Static Site
+
+Environment Variables:
+
+- `NODE_VERSION=18`
+
+SPA fallback via `static.json`
+
 ## Telegram Mini App
 Подключаемые скрипты (в этом порядке):
 1. `tg-viewport.ts`

--- a/index.html
+++ b/index.html
@@ -8,11 +8,11 @@
     />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <title>StarCheckers</title>
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="manifest" href="manifest.json" />
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="src/main.tsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview",
+    "preview": "vite preview --strictPort --port 4173",
     "test": "vitest run",
     "mock:ws": "tsx pages/api/ws-mock.ts"
   },
@@ -38,5 +38,8 @@
     "typescript": "^5.2.0",
     "vite": "^4.4.9",
     "vitest": "^0.34.6"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,9 @@
+services:
+  - type: web
+    name: starcheckers
+    env: static
+    buildCommand: npm ci && npm run build
+    staticPublishPath: dist
+    envVars:
+      - key: NODE_VERSION
+        value: 18

--- a/static.json
+++ b/static.json
@@ -1,0 +1,5 @@
+{
+  "routes": [
+    { "src": "/.*", "dest": "/index.html" }
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,4 +3,5 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  base: './',
 });


### PR DESCRIPTION
## Summary
- configure Render static site deployment with SPA fallback
- ensure Vite uses relative base and index.html assets are relative
- document Render deployment steps

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689caba563708331afa1842efa2c240e