### PR TITLE
fix: ensure root element exists before rendering

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,8 +7,14 @@ import './tg-header-buffer';
 import './layout-engine';
 import './gestures-guard';
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('Root element not found');
+}
+
+ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
+  </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- check DOM for root element and fail fast if missing before React rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689caf477dbc83319a659946933e7e40